### PR TITLE
build: remove unnecessary codecov dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Run coverage
       if: matrix.python-version == '3.8' && matrix.toxenv == 'django32'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         flags: unittests
-        fail_ci_if_error: false  # TODO: set to true after fixing the token error.
+        fail_ci_if_error: true

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests on CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.6.15
     # via requests
 charset-normalizer==2.1.0
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==6.4.2
     # via codecov
 distlib==0.3.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -102,8 +102,6 @@ code-annotations==1.3.0
     #   edx-enterprise
     #   edx-lint
     #   edx-toggles
-codecov==2.1.12
-    # via -r requirements/ci.txt
 commonmark==0.9.1
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
also upgrading the action appears to help with the apparent token upload issue

**Description:** On Wednesday this happened with Codecov: https://about.codecov.io/blog/message-regarding-the-pypi-package/

Since codecov's GHA-based uploader doesn't depend on this package, this PR removes it.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green